### PR TITLE
feat(scram): implement retro feedback from issues #15–#18

### DIFF
--- a/scram/agents/code-maintainer.md
+++ b/scram/agents/code-maintainer.md
@@ -87,6 +87,8 @@ When a developer completes work:
    - **Deletable code** — unused imports, dead branches, orphaned helpers, exports nothing consumes
    - **Streamlineable interfaces** — props/arguments that could be derived, unnecessary indirection, over-abstraction for current usage
    - **Architectural drift** — is this subtly moving the codebase away from its established patterns?
+   - **Scope violations** — flag any code that cannot be traced to an acceptance criterion in the brief. Untraceable code is a scope violation; reject and ask the developer to explain or remove it.
+   - **Bundle size delta** — note the aggregate bundle size change across all merged stories so far. If a single story causes >50% reduction or >20KB absolute change, write a structural signal note in `SCRAM_WORKSPACE/session.md`: `[timestamp] Highfather: bundle delta signal — <story-slug> changed bundle by <delta>`.
 3. **Approve or reject** — when noting pattern observations, include them in review feedback
 
 ### Approval Tiers
@@ -155,6 +157,13 @@ When done with a review or merge, you MUST report using this exact structure:
 ## In-Flight Capture
 
 **In-Flight Capture:** When you encounter process friction during the stream — a confusing instruction, an unexpected git state, an ambiguous handoff — append a one-liner to `SCRAM_WORKSPACE/retro/in-flight.md`. Format: `[timestamp] [role]: <observation>`. Capture and continue. Synthesis happens at G5.
+
+## Shell Scripting Standards
+
+When writing or reviewing shell scripts (in SCRAM workspace or agent outputs):
+- Always use `git rev-parse --verify <ref>` for ref existence checks — never assume a branch or commit exists
+- Every script path must exit with a meaningful exit code (0 = success, non-zero = failure with message to stderr)
+- Scripts that call `git stash` must register a trap to drop the stash on exit: `trap 'git stash drop stash@{0} 2>/dev/null || true' EXIT`
 
 ## Constraints
 

--- a/scram/agents/developer-breakdown.md
+++ b/scram/agents/developer-breakdown.md
@@ -46,6 +46,15 @@ For each story, write a brief to `SCRAM_WORKSPACE/briefs/<story-slug>.md` contai
 ## Doc Section
 <reference to the approved doc section this story maps to>
 
+## Budget
+`tight | standard | open`
+- `tight` — read only this brief and directly referenced files (use for simple, well-scoped stories)
+- `standard` — normal codebase exploration permitted (default)
+- `open` — full codebase exploration permitted (use for complex or cross-cutting stories)
+
+## Scope Fence
+<For stories that touch contested files: explicitly declare which sections/files/functions are OUT OF SCOPE for this story. Example: "Do not modify the authentication middleware — that is owned by story auth-2." Leave blank if no contested files.>
+
 ## Files
 - <file path> — <why it's relevant>
 
@@ -56,12 +65,23 @@ Use content-stable grep anchors. **Never use line numbers.**
 
 ## Types & Interfaces
 - <key type/interface signatures>
+- **If modifying any variant of a generated type (Row/Insert/Update), verify all variants have consistent column sets.** Note which variants exist and confirm parity.
 
 ## Dependencies
-- <stories this depends on, and whether they're merged>
+### Code dependencies
+- <stories this depends on, and whether they're merged — do not dispatch until these are merged>
+
+### Structural dependencies
+- <brief-to-brief format dependencies: "this story extends the manifest format defined in story X">
+- <merge order constraints: "must merge before story Y to avoid ancestry contamination">
 
 ## Architecture
 <summary of relevant architecture and relevant ADRs from G1>
+
+## Hook Constraint Check
+Can this story pass pre-commit hooks independently (without relying on changes from other stories)?
+- Yes / No — <explain if No>
+- If "No": note the export-before-deletion ordering constraint or other hook dependency. This story may need to be sequenced or its scope adjusted.
 
 ## Checklist
 <Story-specific checklist items. Populate only the checklist(s) relevant to this story's domain.
@@ -96,6 +116,33 @@ Apply these when the story touches their domain. Populate the `## Checklist` fie
 
 **Test-update stories**:
 - Do NOT modify application code to make tests pass. If a test cannot pass without changing application code, escalate.
+
+## Retry Briefs
+
+When a story is **rejected** and needs redispatch, write a retry brief rather than editing the original. Retry briefs are separate files at `SCRAM_WORKSPACE/briefs/<story-slug>-retry-<n>.md` and must include:
+
+```markdown
+# <Story Title> — Retry <n>
+
+## Retry of
+<original story slug>
+
+## Removed from Scope
+- <item explicitly removed — was in original ACs but is out of scope for this retry>
+- ...
+
+## Acceptance Criteria Changes
+- **Changed:** <original AC> → <revised AC>
+- **Added:** <new AC not in original>
+- **Removed:** <AC removed from this retry>
+
+## Why This Failed
+<factual summary of the prior failure reason from the Story Report>
+
+## <all other standard sections (Files, Locators, Types, Dependencies, etc.)>
+```
+
+The dispatch prompt must reference the retry brief file path, not inline the original brief.
 
 ## Output Rules
 

--- a/scram/agents/developer-impl.md
+++ b/scram/agents/developer-impl.md
@@ -30,6 +30,7 @@ When assigned a story (including escalated stories that failed on a previous att
    git checkout -b <integration-branch>/<story-slug>
    ```
    The integration branch name is provided in your dispatch prompt. **NEVER work directly on `main`.**
+   **NEVER work from a rejected branch** — if you receive a redispatch, always branch fresh from the current integration branch tip, not from the prior story's branch.
 2. **Isolation Contract** — before making ANY file modifications, verify all four:
    - `pwd` is within your assigned worktree path (not the main repo)
    - `git rev-parse --abbrev-ref HEAD` matches your story branch (`<integration-branch>/<story-slug>`)
@@ -51,9 +52,10 @@ Before writing any code, verify:
 ## Reading
 
 1. **Read the docs-as-spec** — the approved documentation is your source of truth
-2. **Read the context brief** — understand files, types, and interfaces (including relevant ADRs and the `## Checklist` section)
+2. **Read the context brief** — understand files, types, and interfaces (including relevant ADRs, `## Checklist`, and `## Scope Fence` sections). The context budget field governs how much additional exploration you may do: `tight` = read only this brief and directly referenced files; `standard` = normal exploration; `open` = full codebase exploration permitted.
 3. **Read project conventions** — check CLAUDE.md at root and in relevant packages
 4. **Find existing patterns** — look at similar implementations to follow the same structure
+5. **Scope discipline** — implement ONLY what satisfies this story's acceptance criteria. No stubs, scaffolding, or infrastructure for future stories. If you encounter adjacent bugs, document them in your Story Report — do not fix them in this commit. Reviewers will flag untraceable code as a scope violation.
 
 ## RED — Write Failing Tests
 
@@ -91,6 +93,23 @@ When receiving an escalated story (one that failed on a previous attempt), you a
 - Include: what you completed, what remains, and any partial work in progress
 - The maintainers will dispatch a fresh agent to continue
 
+## One-Commit Self-Check
+
+Before generating your Story Report, verify the commit count:
+
+```bash
+git rev-list --count --no-merges <integration-branch>..HEAD
+```
+
+This count MUST be exactly `1`. If it is greater than 1, squash all commits into one before reporting:
+
+```bash
+git rebase -i <integration-branch>
+# in the editor: change all "pick" to "squash" except the first
+```
+
+Include the final commit count in your Story Report. Do not report completion until the count is exactly 1.
+
 ## Story Report
 
 When done, you MUST report using this exact structure:
@@ -104,11 +123,13 @@ When done, you MUST report using this exact structure:
 - **Phase reached:** RED | GREEN | REFACTOR
 - **Failure reason:** none | context_exhaustion | test_failure | build_error | missing_dependency | unclear_spec | pre_flight_failure
 - **Failure details:** <specific error message or description, if failed>
+- **Commit count:** <output of `git rev-list --count --no-merges <integration-branch>..HEAD` — must be 1>
 - **Files changed:**
   - <file path> — <brief description>
 - **Tests:** <pass count>/<total count> passing
 - **Pre-existing issues:** <list or "none">
 - **Design decisions:** <any architectural choices made and why>
+- **Adjacent issues found:** <bugs or problems found but not fixed — document here for orchestrator>
 - **Remaining work:** <what's left, if partial>
 - **Escalation notes:** <if escalated: what was different from previous attempt>
 ```

--- a/scram/agents/merge-maintainer.md
+++ b/scram/agents/merge-maintainer.md
@@ -80,7 +80,11 @@ When a developer completes work:
 3. **Check for**:
    - Tests covering the documented behavior (derived from docs, not implementation)
    - Red-Green-Refactor discipline: tests exist before implementation, tests pass, code is refactored
-   - **Scope discipline** — reject changes beyond the story. No bonus refactors, no "while I'm here" additions.
+   - **Scope discipline** — reject changes beyond the story. No bonus refactors, no "while I'm here" additions. Flag any code that cannot be traced to an acceptance criterion as a scope violation.
+   - **Commit count** — verify exactly one commit on the story branch relative to the integration branch: `git rev-list --count --no-merges <integration-branch>..<story-branch>`. Require the developer to squash before approval if count > 1.
+   - **Diff isolation** — verify the diff's changed files exactly match the brief's `## Deliverables`. Changes outside the declared files require explanation or rejection.
+   - **Ancestry check** — verify the story branch was created from the integration branch tip, not from `main` or a sibling story branch: `git merge-base --is-ancestor <integration-tip> <story-branch>`.
+   - **Generated type parity** — when any variant of a generated type (Row/Insert/Update) is modified, verify all variants have consistent column sets.
    - **Edge cases** — are error paths, boundary conditions, and null/empty cases handled?
    - **Naming and formatting** — consistent, descriptive, following CLAUDE.md conventions exactly
    - **Test quality** — do tests assert the right things? Are they testing behavior or implementation details?
@@ -92,9 +96,20 @@ When a developer completes work:
 - **Simple stories**: single maintainer approval sufficient (either merge or code maintainer)
 - **Moderate and complex stories**: both maintainers must independently approve
 
+### Approval Records
+
+Before merging any moderate or complex story, write an explicit approval record to `SCRAM_WORKSPACE/session.md` under a `## Approvals` section:
+
+```
+[YYYY-MM-DDTHH:MM:SSZ] Metron: approved <story-slug>
+[YYYY-MM-DDTHH:MM:SSZ] Highfather: approved <story-slug>
+```
+
+The merge is **gated** on both approval records existing for moderate/complex stories — not just accompanied by them. Do not begin the merge procedure until both records are written.
+
 ### Merging (atomic, per-story)
 
-After approval:
+After approval records are written:
 
 1. Copy files from worktree to integration branch
 2. Stage specific files (no `git add -A`)

--- a/scram/scripts/session-checkpoint.sh
+++ b/scram/scripts/session-checkpoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# session-checkpoint.sh — Write a last-seen timestamp to an active SCRAM session manifest.
+# session-checkpoint.sh — Write a last-seen timestamp to an active SCRAM session manifest
+# and append a checkpoint event to events/stream.log.
 # Registered as a Stop hook. Always exits 0.
 
 # No-op if SCRAM_WORKSPACE is unset or empty
@@ -31,5 +32,11 @@ updated: $TIMESTAMP" "$SESSION_FILE"
     rm -f "$SESSION_FILE.bak"
   fi
 fi
+
+# Append checkpoint event to events/stream.log
+EVENTS_DIR="$SCRAM_WORKSPACE/events"
+mkdir -p "$EVENTS_DIR" 2>/dev/null || true
+GATE=$(grep '^current_gate:' "$SESSION_FILE" 2>/dev/null | sed 's/^current_gate:[[:space:]]*//' | tr -d '"' | tr -d "'" | head -1)
+echo "{\"ts\":\"$TIMESTAMP\",\"type\":\"checkpoint\",\"gate\":\"${GATE:-unknown}\"}" >> "$EVENTS_DIR/stream.log"
 
 exit 0

--- a/scram/skills/scram/SKILL.md
+++ b/scram/skills/scram/SKILL.md
@@ -75,7 +75,8 @@ SCRAM persists state in a **global workspace directory** outside the project rep
     │   │   └── highfather.md
     │   └── discussions/
     │       └── <topic-slug>.md # consensus discussion outputs
-    └── events/                 # reserved for future use
+    └── events/
+    │   └── stream.log          # checkpoint event log — one JSON line per Stop hook invocation
 ```
 
 **Workspace path construction** (at G0):
@@ -94,6 +95,8 @@ The workspace path is determined at G0 and passed to all agents as an **absolute
 
 The workspace is cleaned up at the user's discretion after the SCRAM run. The orchestrator reports the workspace path in the final summary.
 
+**Resuming a session:** Read `session.md` to restore state. Also read the last 5 lines of `events/stream.log` (if it exists) to understand the most recent activity before context was lost. This gives a mechanical checkpoint trace that supplements the prose state in `session.md`.
+
 ### Session Manifest
 
 The session manifest (`SCRAM_WORKSPACE/session.md`) is the single file needed to resume a SCRAM run. It is written at G0 and **updated after every gate transition and every story merge**. Format:
@@ -107,6 +110,7 @@ workspace: <absolute SCRAM_WORKSPACE path>
 current_gate: G0 | G1 | G2 | G3 | streams | G4 | G5 | complete
 run_type: code | docs | mixed
 retrospective: pending | true | false
+# retrospective transitions: set to "pending" at G0; resolve to "true" (opted in) or "false" (opted out) at G4 after the user prompt; never resolve during the stream phase
 prior_brainstorm: <absolute path to brainstorm workspace, or "none">
 compressed_gates: <comma-separated list of skipped gates, e.g. "G1, G2", or "none">
 tracker: <tracker config or "none">
@@ -221,7 +225,19 @@ Resume an existing session, or start fresh?
 
 ### New Session Setup
 
+**Stash check precondition:** Before creating the integration branch or workspace, verify no stashes exist:
+```bash
+git stash list
+```
+If stashes exist, stop and notify the user. Do not proceed until the user explicitly clears or acknowledges existing stashes. Starting a SCRAM run with stashes present risks accidental loss during G4 teardown.
+
 Both maintainers run environment checks and create the integration branch per their agent definitions. The orchestrator creates the SCRAM workspace using `scram-init.sh` and writes the session manifest.
+
+**Gate-boundary events:** Write a JSON event to `SCRAM_WORKSPACE/events/stream.log` at each gate transition:
+```bash
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"gate\",\"gate\":\"G1\"}" >> "$SCRAM_WORKSPACE/events/stream.log"
+```
+The `session-checkpoint.sh` Stop hook appends checkpoint events automatically between gate transitions.
 
 ### Gather Requirements
 
@@ -296,6 +312,17 @@ Evaluate the scope to determine the session tier:
 |------|----------|------|
 | **Full** | 4+ stories, moderate/complex complexity, shared package changes, or new abstractions | Full team with persistent maintainer team |
 | **Lightweight** | ≤3 stories, all simple or verify-only, no shared package changes, no new abstractions | Single maintainer, no persistent team needed |
+| **Quick** | 1 story, verify-only or trivially isolated, no new files, no shared state changes | Orchestrator handles directly — no dev dispatch, no maintainer team |
+| **Nano** | 1 story, ≤2 files modified, no new abstractions, no concurrent streams | Abbreviated flow: G0 preconditions + single one-shot dev + G4 review only |
+
+**Quick tier:** The orchestrator directly verifies acceptance criteria (no dev dispatch). Record outcome in `session.md` with an inline checklist:
+- [ ] Criteria verified: <specific AC>
+- [ ] No changes required OR changes confirmed in-place
+- [ ] Session manifest updated
+
+**Nano tier:** G1/G2/G3 are skipped by default. Use `scram/nano/<story-slug>` as the feature branch (no separate integration branch). Dispatch a single `scram:developer-impl` one-shot. G4 review is always required (never skip). If scope exceeds ≤2 files mid-run, escalate to Lightweight — write the escalation to `session.md` and ask the user before continuing.
+
+**Nano workspace:** `scram-init.sh --nano` (or manual) creates a minimal workspace: `session.md` and `events/` only. No `briefs/` or `retro/` directories needed for Nano.
 
 For lightweight sessions, a single maintainer handles review. The orchestrator **must not merge directly** — even lightweight sessions require an explicit review checklist:
 - [ ] Acceptance criteria checked against story brief
@@ -440,6 +467,12 @@ Dispatch `scram:developer-breakdown` without worktree isolation — Tier 2 dispa
 ## Doc Section
 <reference to the approved doc section this story maps to>
 
+## Budget
+`tight | standard | open`
+
+## Scope Fence
+<For contested-file stories: explicit declaration of which sections/files are OUT OF SCOPE. Leave blank if no contested files.>
+
 ## Files
 - <file path> — <why it's relevant>
 
@@ -452,7 +485,14 @@ Use content-stable grep anchors to identify locations in files. **Never use line
 - <key type/interface signatures>
 
 ## Dependencies
+### Code dependencies
 - <stories this depends on, and whether they're merged>
+
+### Structural dependencies
+- <brief-to-brief format dependencies; merge order constraints>
+
+## Hook Constraint Check
+Can this story pass pre-commit hooks independently? Yes / No — <explain if No>
 
 ## Architecture
 <summary of relevant architecture and relevant ADRs from G1>
@@ -592,27 +632,31 @@ If the script is unavailable, run manually:
 
 The `worktree-init.sh` script enforces isolation mechanically — it verifies the agent is in a worktree (not the main repo), confirms the worktree is based on the integration branch, creates the story branch, and verifies HEAD. It exits non-zero with a clear error on any check failure, preventing agents from committing to the wrong branch.
 
-Each agent receives in its dispatch prompt:
-- Story ID and description with acceptance criteria
+**Thin orchestrator discipline:** Pass paths, not contents. Each agent dispatch includes:
+- Story ID and slug
 - SCRAM workspace path (absolute)
-- Context brief file path (`SCRAM_WORKSPACE/briefs/<story-slug>.md`)
-- Doc section reference
+- Context brief file path (`SCRAM_WORKSPACE/briefs/<story-slug>.md`) — the agent reads this from disk
 - **Integration branch name** — the agent MUST branch from this, not from `main`
 - The checkout instructions above
 
-Dispatch `scram:developer-impl` with the context brief — the agent follows its TDD discipline as defined in its agent file.
+Do not embed brief contents, doc sections, or file contents inline in the dispatch prompt. Agents read their own context from disk. This prevents context bloat and ensures agents work from current disk state rather than stale embedded snapshots.
+
+Dispatch `scram:developer-impl` with the context brief path — the agent follows its TDD discipline as defined in its agent file.
 
 **Dispatch rules:**
 - **P0 stories run first as a separate wave** with a quality gate before P1+ begins. This gates complex work on a proven baseline.
 - Max **5 concurrent dev agents**
 - Each agent works **one story at a time**, completing all three phases
-- **Do not dispatch a story whose `Depends On` column has unmerged stories** — check backlog status first
+- **Do not dispatch a story whose `Depends On` column has unmerged stories** — check backlog status first. Dependency must be merged into the integration branch before the dependent story is dispatched.
+- **Verify branch name convention before dispatch** — the story slug must produce a branch name following `scram/<feature>/<story-slug>`. If the branch already exists (prior rejected attempt), do not reuse it — the dev agent will create a fresh branch from integration tip.
 - **Stories with migrations serialize** — do not parallelize stories that include migrations touching the same tables
 - Use the model matching the story's complexity tag
 - Agents return a **structured Story Report** (including branch name and commit SHA) to the maintainers when complete
 - Pull-based: as an agent finishes, maintainers dispatch the next story from the backlog
 
-**Contested files:** During G3 backlog construction, identify stories that touch the same files. Add a `Contested Files` note. Same-file stories should be assigned to the same agent or given explicit merge-order annotations to avoid conflicts.
+**Contested files:** During G3 backlog construction, identify stories that touch the same files. Add a `Contested Files` note and populate the story's `## Scope Fence` section in its brief. Same-file stories should be assigned to the same agent or given explicit merge-order annotations in the brief's `## Dependencies` section to avoid conflicts.
+
+**Hook constraint audit (G3):** For each story, confirm it can pass pre-commit hooks independently without relying on changes from sibling stories. The export-before-deletion ordering is a named anti-pattern: if story A removes an export that story B depends on, story B must be fully merged before story A is dispatched. Record this in both stories' `## Dependencies` sections.
 
 **Escalation on failure (using failure taxonomy):**
 
@@ -636,6 +680,10 @@ Default escalation path for capability failures: sonnet → opus. **If the same 
 
 **Attempted:** <what was tried>
 **Failed because:** <root cause>
+**Checkpoint type:** human-verify | decision | human-action
+  - `human-verify` — read and confirm, no action required from you
+  - `decision` — choose between the options below
+  - `human-action` — you need to perform an action before the run can continue
 **Decision needed:** <closed question with specific options>
 **Options:**
 1. <option A> — <consequence>
@@ -650,6 +698,8 @@ Both maintainers are persistent teammates. As each dev agent completes:
 Dispatch Metron with the Story Report. Metron performs pre-review git health checks, dual-approval coordination, and merge execution per its agent definition.
 
 **If tests or typecheck fail after merge:** Revert immediately. Write `HALT` file to SCRAM workspace. Update backlog status to `failed`. Do NOT merge further stories until integration branch is green and `HALT` is removed.
+
+**Rejected branch lifecycle:** When a story is rejected, abandon the branch — do not amend it, cherry-pick from it, or redispatch into it. Write a retry brief (`briefs/<slug>-retry-<n>.md`) documenting removed scope and changed ACs. Redispatch always branches fresh from the current integration branch tip. Maintainers verify diff isolation during review: the story's diff must exactly match the brief's `## Deliverables` with no ancestry contamination from sibling branches.
 
 **Cherry-Pick Fallback (last resort):**
 When worktree isolation fails and an agent commits on the wrong branch, cherry-picking to the integration branch is permitted only if BOTH conditions are met:
@@ -683,7 +733,8 @@ After all three streams complete:
 4. Run full test suite one final time
 5. Verify docs and ADRs accurately reflect the final implementation
 6. Verify `SCRAM_WORKSPACE/backlog.md` shows all stories as `merged`
-7. Close remaining tracker issues (if configured), add summary comment
+7. **Stash cleanup:** Run `git stash list`. If any stashes exist, notify the user with stash details and offer to drop them. Do not silently drop stashes — they may contain user work.
+8. Close remaining tracker issues (if configured), add summary comment
 8. Ask the user about a retrospective now that they have seen the completed work:
 
 ```
@@ -756,5 +807,6 @@ The user can continue in a fresh session. The new orchestrator will find the wor
 - New commits only — never amend
 - One atomic commit per story
 - SCRAM workspace is outside the project repo — never committed to git
+- **Post-merge fixes go through story lifecycle** — no informal patches on the integration branch. Any defect discovered post-merge requires a backlog entry, context brief, and clean commit through normal dispatch. This preserves the one-commit-per-story invariant and ensures dual-approval is never bypassed.
 - **G2 doc work MUST use `scram:doc-specialist` agents** — developers may not substitute for doc specialists at G2
 - **External service work** — when agents update external services via API (not git-tracked files), use the staging pattern: write proposed content to local files in the worktree first, maintainers review those files as a diff, only after approval does a final step push to the external service. This preserves the review gate for side-effectful work.


### PR DESCRIPTION
## Summary

- Closes #15, #16, #17, #18 — implements all consensus changes from 4 SCRAM retro runs
- Adds Quick and Nano session tiers; activates `events/stream.log`; adds stash lifecycle guards; strengthens scope, approval, and isolation invariants across all agents

## Changes by file

**`SKILL.md`** — Quick/Nano tiers, G0 stash check, gate-boundary event writes, resume via `stream.log`, thin orchestrator discipline, checkpoint_type taxonomy, retrospective field transitions, rejected branch lifecycle, hook constraint audit at G3, stash cleanup at G4, no-informal-patches constraint, updated brief format (Budget, Scope Fence, split Dependencies, Hook Constraint Check)

**`session-checkpoint.sh`** — appends `{"ts","type","gate"}` JSON event to `events/stream.log` on every Stop hook

**`developer-impl.md`** — scope discipline reading step, rejected-branch guard, one-commit self-check section, commit count + adjacent issues fields in Story Report

**`developer-breakdown.md`** — Budget, Scope Fence, split Dependencies, Hook Constraint Check, type parity note in Types & Interfaces, structured retry brief format

**`merge-maintainer.md`** — commit count check, diff isolation check, ancestry check, type parity check, scope violation flag in review checklist; Approval Records section (gated, not accompanied)

**`code-maintainer.md`** — scope violation detection, bundle size delta reporting, Shell Scripting Standards (rev-parse --verify, exit codes, stash trap)

## Test plan

- [ ] `claude plugin validate ./scram` passes
- [ ] Review brief format changes are consistent between SKILL.md and developer-breakdown.md
- [ ] Verify session-checkpoint.sh produces valid JSON lines in events/stream.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)