### PR TITLE
chore(scram): bump version to 6.1.0

### DIFF
--- a/scram/.claude-plugin/plugin.json
+++ b/scram/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scram",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "SCRAM — Structured Collaborative Review and Merge with stream-based parallel development",
   "author": {
     "name": "alxjrvs",


### PR DESCRIPTION
## Summary
- Bumps scram plugin version from 6.0.0 to 6.1.0

## Test plan
- [ ] Verify plugin validates with `claude plugin validate ./scram`

🤖 Generated with [Claude Code](https://claude.com/claude-code)